### PR TITLE
[Sikkerhet] Flytter security champion til SMIA

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @lislei
+/.sikkerhet/ @AleksanderWK


### PR DESCRIPTION
Denne brukes kun av Stedsnavn, så det er naturlig at Security Champion for SMIA overtar også denne. 