### PR TITLE
[Sikkerhet] Oppretter sikkerhetsfiler description.yaml og catalog-info.yaml og setter security champion i CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-/.security/ @AleksanderWK
-/.security/ @lislei
-/.security/ @lislei
 /.security/ @lislei

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
-/.sikkerhet/ @AleksanderWK
+/.security/ @AleksanderWK
+/.security/ @lislei
+/.security/ @lislei
+/.security/ @lislei

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,0 +1,4 @@
+organization: Eiendom
+product: Geotools
+repo_types: [Library]
+platforms: [LOKALT]

--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,0 @@
-version: 1.0
-organisasjon: Eiendom

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "geotools"
+  tags:
+  - "public"
+spec:
+  type: "library"
+  lifecycle: "production"
+  owner: "heimdall"
+  system: "matrikkel"


### PR DESCRIPTION
Denne PRen setter security champion i git-repoet ved å legge til `@lislei` i CODEOWNER-filen.
Videre opprettes description-filen under .security-mappen med følgende felter:

- `organization: Eiendom`
- `product: Geotools`
- `repo_types: [Library]`
- `platforms: [LOKALT]`

Oppretter også `catalog-info.yaml` hvis den ikke finnes fra før. Dette gjør at repoet kan legges inn inn i utviklerportalen [kartverket.dev](https://kartverket.dev/).

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.